### PR TITLE
fix #23 error encoding timestamps when persisting entities

### DIFF
--- a/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/R2dbcQueryStatement.java
+++ b/data-r2dbc/src/main/java/io/micronaut/data/r2dbc/mapper/R2dbcQueryStatement.java
@@ -23,6 +23,7 @@ import io.micronaut.data.runtime.mapper.QueryStatement;
 import io.r2dbc.spi.Statement;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 /**
@@ -79,10 +80,11 @@ public class R2dbcQueryStatement implements QueryStatement<Statement, Integer> {
     @NonNull
     @Override
     public QueryStatement<Statement, Integer> setTimestamp(Statement statement, Integer name, Date date) {
-        if (date == null) {
+        LocalDateTime localDate = convertRequired(date, LocalDateTime.class);
+        if (localDate == null) {
             statement.bindNull(name, Date.class);
         } else {
-            statement.bind(name, date);
+            statement.bind(name, localDate);
         }
         return this;
     }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2JoinOneSpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2JoinOneSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.tck.entities.Owner
 import io.micronaut.data.tck.entities.Pet
+import io.micronaut.data.tck.entities.Product
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Shared
 

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2ReactiveProductRepository.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2ReactiveProductRepository.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.data.r2dbc
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@R2dbcRepository(dialect = Dialect.H2)
+interface H2ReactiveProductRepository extends ProductReactiveRepository {}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2ReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/H2ReactiveRepositorySpec.groovy
@@ -4,7 +4,6 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.data.r2dbc.operations.R2dbcOperations
 import io.micronaut.data.tck.entities.Person
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
-import io.micronaut.data.tck.tests.AbstractReactiveRepositorySpec
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus
 import io.r2dbc.spi.Connection
@@ -24,6 +23,10 @@ class H2ReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
 
     @Inject
     @Shared
+    H2ReactiveProductRepository productReactiveRepository
+
+    @Inject
+    @Shared
     ConnectionFactory connectionFactory
 
     @Inject
@@ -33,6 +36,11 @@ class H2ReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     @Override
     PersonReactiveRepository getPersonRepository() {
         return personReactiveRepository
+    }
+
+    @Override
+    ProductReactiveRepository getProductRepository() {
+        return productReactiveRepository
     }
 
     void 'test with transactional connection'() {
@@ -53,6 +61,11 @@ class H2ReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
         Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
             status.connection.createStatement(
                 "CREATE TABLE `person` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `age` INT, `enabled` BIT);"
+            ).execute()
+        })).block()
+        Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
+            status.connection.createStatement(
+                "CREATE TABLE `product` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `price` DECIMAL, `date_created` DATETIME NULL, `last_updated` DATETIME NULL);"
             ).execute()
         })).block()
     }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MariaDbReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MariaDbReactiveRepositorySpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.data.r2dbc
 import io.micronaut.context.annotation.Property
 import io.micronaut.data.r2dbc.operations.R2dbcOperations
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
-import io.micronaut.data.tck.tests.AbstractReactiveRepositorySpec
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus
 import io.r2dbc.spi.Connection
@@ -22,6 +21,10 @@ class MariaDbReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
 
     @Inject
     @Shared
+    MySqlProductRepository productReactiveRepository
+
+    @Inject
+    @Shared
     ConnectionFactory connectionFactory
 
     @Inject
@@ -34,10 +37,20 @@ class MariaDbReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     }
 
     @Override
+    ProductReactiveRepository getProductRepository() {
+        return productReactiveRepository
+    }
+
+    @Override
     void init() {
         Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
             status.connection.createStatement(
                     "CREATE TABLE `person` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `age` INT, `enabled` BIT);"
+            ).execute()
+        })).block()
+        Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
+            status.connection.createStatement(
+                "CREATE TABLE `product` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `price` DECIMAL, `date_created` DATETIME NULL, `last_updated` DATETIME NULL);"
             ).execute()
         })).block()
     }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MssqlProductRepository.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MssqlProductRepository.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.data.r2dbc
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@R2dbcRepository(dialect = Dialect.SQL_SERVER)
+interface MssqlProductRepository extends ProductReactiveRepository {
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MssqlReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MssqlReactiveRepositorySpec.groovy
@@ -6,8 +6,8 @@ import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder
 import io.micronaut.data.r2dbc.operations.R2dbcOperations
 import io.micronaut.data.tck.entities.Person
+import io.micronaut.data.tck.entities.Product
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
-import io.micronaut.data.tck.tests.AbstractReactiveRepositorySpec
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus
 import io.r2dbc.spi.Connection
@@ -26,6 +26,10 @@ class MssqlReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
 
     @Inject
     @Shared
+    MssqlProductRepository productReactiveRepository
+
+    @Inject
+    @Shared
     ConnectionFactory connectionFactory
 
     @Inject
@@ -38,9 +42,14 @@ class MssqlReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     }
 
     @Override
+    ProductReactiveRepository getProductRepository() {
+        return productReactiveRepository
+    }
+
+    @Override
     void init() {
         def sqlBuilder = new SqlQueryBuilder(Dialect.SQL_SERVER)
-        def statement = sqlBuilder.buildBatchCreateTableStatement(PersistentEntity.of(Person))
+        def statement = sqlBuilder.buildBatchCreateTableStatement(PersistentEntity.of(Person), PersistentEntity.of(Product))
         Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
             status.connection.createStatement(statement).execute()
         })).block()

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MySqlProductRepository.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MySqlProductRepository.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.data.r2dbc
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@R2dbcRepository(dialect = Dialect.MYSQL)
+interface MySqlProductRepository extends ProductReactiveRepository {
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MySqlReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/MySqlReactiveRepositorySpec.groovy
@@ -2,9 +2,7 @@ package io.micronaut.data.r2dbc
 
 import io.micronaut.context.annotation.Property
 import io.micronaut.data.r2dbc.operations.R2dbcOperations
-import io.micronaut.data.tck.entities.Person
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
-import io.micronaut.data.tck.tests.AbstractReactiveRepositorySpec
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus
 import io.r2dbc.spi.Connection
@@ -23,6 +21,10 @@ class MySqlReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
 
     @Inject
     @Shared
+    MySqlProductRepository productReactiveRepository
+
+    @Inject
+    @Shared
     ConnectionFactory connectionFactory
 
     @Inject
@@ -35,10 +37,20 @@ class MySqlReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     }
 
     @Override
+    ProductReactiveRepository getProductRepository() {
+        return productReactiveRepository
+    }
+
+    @Override
     void init() {
         Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
             status.connection.createStatement(
                     "CREATE TABLE `person` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `age` INT, `enabled` BIT);"
+            ).execute()
+        })).block()
+        Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
+            status.connection.createStatement(
+                "CREATE TABLE `product` (`id` BIGINT AUTO_INCREMENT PRIMARY KEY,`name` VARCHAR(255) NOT NULL, `price` DECIMAL, `date_created` DATETIME NULL, `last_updated` DATETIME NULL);"
             ).execute()
         })).block()
     }

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PostgresProductRepository.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PostgresProductRepository.groovy
@@ -1,0 +1,8 @@
+package io.micronaut.data.r2dbc
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+
+@R2dbcRepository(dialect = Dialect.POSTGRES)
+interface PostgresProductRepository extends ProductReactiveRepository {
+}

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PostgresReactiveRepositorySpec.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/PostgresReactiveRepositorySpec.groovy
@@ -6,12 +6,12 @@ import io.micronaut.data.model.query.builder.sql.Dialect
 import io.micronaut.data.model.query.builder.sql.SqlQueryBuilder
 import io.micronaut.data.r2dbc.operations.R2dbcOperations
 import io.micronaut.data.tck.entities.Person
+import io.micronaut.data.tck.entities.Product
 import io.micronaut.data.tck.repositories.PersonReactiveRepository
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.transaction.reactive.ReactiveTransactionStatus
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.ConnectionFactory
-import io.r2dbc.spi.Result
 import reactor.core.publisher.Mono
 import spock.lang.Shared
 
@@ -23,6 +23,10 @@ class PostgresReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     @Inject
     @Shared
     PostgresPersonRepository personReactiveRepository
+
+    @Inject
+    @Shared
+    PostgresProductRepository productReactiveRepository
 
     @Inject
     @Shared
@@ -38,9 +42,14 @@ class PostgresReactiveRepositorySpec extends AbstractReactiveRepositorySpec {
     }
 
     @Override
+    ProductReactiveRepository getProductRepository() {
+        return productReactiveRepository
+    }
+
+    @Override
     void init() {
         def sqlBuilder = new SqlQueryBuilder(Dialect.POSTGRES)
-        def statement = sqlBuilder.buildBatchCreateTableStatement(PersistentEntity.of(Person))
+        def statement = sqlBuilder.buildBatchCreateTableStatement(PersistentEntity.of(Person), PersistentEntity.of(Product))
         Mono.from(r2dbcOperations.withTransaction({ ReactiveTransactionStatus<Connection> status ->
             status.connection.createStatement(statement).execute()
         })).block()

--- a/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ProductReactiveRepository.groovy
+++ b/data-r2dbc/src/test/groovy/io/micronaut/data/r2dbc/ProductReactiveRepository.groovy
@@ -1,0 +1,7 @@
+package io.micronaut.data.r2dbc
+
+import io.micronaut.data.repository.reactive.RxJavaCrudRepository
+import io.micronaut.data.tck.entities.Product
+
+interface ProductReactiveRepository extends RxJavaCrudRepository<Product, Long> {
+}


### PR DESCRIPTION
The codecs in the R2DBC driver do not know how to handle `java.util.Data` or its subclasses. The quick fix was to convert the `java.util.Date` into an `java.time.LocalDateTime` that the codecs and drivers can handle.

It also looks like some of the R2DBC tests were inheriting from the wrong base specification.

Fixes issue #23