### PR TITLE
Fixed 'native tests skipped' issue

### DIFF
--- a/test-graalvm/common-tests/src/main/java/example/controllers/TestApp.java
+++ b/test-graalvm/common-tests/src/main/java/example/controllers/TestApp.java
@@ -35,7 +35,6 @@ import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import testgraalvm.controllers.dto.OwnerDto;
 import testgraalvm.controllers.dto.PetDto;
 
@@ -47,7 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @MicronautTest(transactional = false)
 public class TestApp implements TestPropertyProvider {


### PR DESCRIPTION
Tests were skipped when running in native image. The following warning was logged:
`Attempted to read Testcontainers configuration file at file:/home/runner/.testcontainers.properties but the file was not found. Exception message: FileNotFoundException: /home/runner/.testcontainers.properties (No such file or directory)`