### PR TITLE
Adding back dev.miku mysql r2dbc library support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ managed-r2dbc = "1.0.0.RELEASE"
 managed-r2dbc-pool = "1.0.0.RELEASE"
 
 managed-r2dbc-oracle = "1.1.1"
-managed-r2dbc-mysql = "1.0.1"
+managed-r2dbc-mysql = "0.8.2.RELEASE"
 managed-r2dbc-h2 = "1.0.0.RELEASE"
 managed-r2dbc-mariadb = "1.1.4"
 managed-r2dbc-postgresql = "1.0.1.RELEASE"
@@ -31,8 +31,8 @@ managed-r2dbc-mssql = "1.0.0.RELEASE"
 
 # Gradle plugins
 
-micronaut-gradle-plugin = "4.0.0-M3"
-micronaut-testresources = "2.0.0-M7"
+micronaut-gradle-plugin = "4.0.0-M2"
+micronaut-testresources = "2.0.0-M5"
 kotlin-gradle-plugin = "1.8.21"
 
 [libraries]
@@ -59,7 +59,7 @@ managed-r2dbc-pool = { module = "io.r2dbc:r2dbc-pool", version.ref = "managed-r2
 managed-r2dbc-h2 = { module = "io.r2dbc:r2dbc-h2", version.ref = "managed-r2dbc-h2" }
 managed-r2dbc-oracle = { module = "com.oracle.database.r2dbc:oracle-r2dbc", version.ref = "managed-r2dbc-oracle" }
 managed-r2dbc-mariadb = { module = "org.mariadb:r2dbc-mariadb", version.ref = "managed-r2dbc-mariadb" }
-managed-r2dbc-mysql = { module = "io.asyncer:r2dbc-mysql", version.ref = "managed-r2dbc-mysql" }
+managed-r2dbc-mysql = { module = "dev.miku:r2dbc-mysql", version.ref = "managed-r2dbc-mysql" }
 managed-r2dbc-mssql = { module = "io.r2dbc:r2dbc-mssql", version.ref = "managed-r2dbc-mssql" }
 managed-r2dbc-postgresql = { module = "org.postgresql:r2dbc-postgresql", version.ref = "managed-r2dbc-postgresql" }
 

--- a/src/main/docs/guide/availableDrivers.adoc
+++ b/src/main/docs/guide/availableDrivers.adoc
@@ -14,7 +14,7 @@ dependency:com.h2database:h2[scope="runtimeOnly"]
 
 R2DBC Driver:
 
-dependency:io.asyncer:r2dbc-mysql[scope="runtimeOnly"]
+dependency:dev.miku:r2dbc-mysql[scope="runtimeOnly"]
 
 And for Flyway migrations the JDBC driver:
 

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -18,7 +18,7 @@ $ curl https://launch.micronaut.io/demo.zip?lang=java&features=data-r2dbc,flyway
 
 The generated application will use MySQL since we passed the `mysql` feature adding dependency on the R2DBC driver for MySQL:
 
-dependency:io.asyncer:r2dbc-mysql[scope="runtimeOnly"]
+dependency:dev.miku:r2dbc-mysql[scope="runtimeOnly"]
 
 And for flyway the JDBC driver:
 


### PR DESCRIPTION
Need to revert this, tests passed in r2dbc but are failing in micronaut-data. This does not appear to be reliable library yet, at least not compatible with retrieving results as previous one we used.