### PR TITLE
Minor release: Remove Testcontainers managed version and bom

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-example.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.r2dbc-example.gradle
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly(libs.flyway.mysql)
 
     testImplementation(mn.micronaut.http.client)
-    testImplementation(platform(libs.boms.testcontainers))
+    testImplementation(platform(libs.testcontainers))
     testImplementation(libs.testcontainers.mysql)
     testImplementation(mnTest.micronaut.test.core)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.1.1-SNAPSHOT
+projectVersion=5.2.0-SNAPSHOT
 projectGroup=io.micronaut.r2dbc
 
 title=Micronaut R2DBC

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ micronaut-validation = "4.1.0"
 micronaut-logging = "1.1.2"
 
 groovy = "4.0.13"
-managed-testcontainers = "1.19.1"
+testcontainers = "1.19.1"
 
 # R2DBC Drivers
 
@@ -51,7 +51,7 @@ micronaut-flyway = { module = "io.micronaut.flyway:micronaut-flyway-bom", versio
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
 
-boms-testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "managed-testcontainers" }
+testcontainers = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
 
 # R2DBC API
 

--- a/r2dbc-bom/build.gradle
+++ b/r2dbc-bom/build.gradle
@@ -6,4 +6,10 @@ micronautBom {
     excludeProject.set({ p ->
         p.group.contains('example') || p.name.contains('example') || p.name.contains('test-')
     } as Spec<Project>)
+
+    suppressions {
+        // We used to erroneously manage testcontainers (prior to 5.2.0)
+        acceptedLibraryRegressions.add("boms-testcontainers")
+        acceptedVersionRegressions.add("testcontainers")
+    }
 }

--- a/r2dbc-core/build.gradle
+++ b/r2dbc-core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     testImplementation(mnRxjava2.micronaut.rxjava2)
     testImplementation(libs.testcontainers.r2dbc)
-    testImplementation(platform(libs.boms.testcontainers))
+    testImplementation(platform(libs.testcontainers))
 
     // mariadb
     testImplementation(libs.managed.r2dbc.mariadb)

--- a/test-graalvm/common-tests/build.gradle
+++ b/test-graalvm/common-tests/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation(mn.micronaut.http.client)
     implementation(mnTest.micronaut.test.junit5)
     implementation(libs.micronaut.testresources.client)
-    implementation(platform(libs.boms.testcontainers))
+    implementation(platform(libs.testcontainers))
     implementation(libs.testcontainers.junit.jupiter)
 
 }


### PR DESCRIPTION
This module erroneously manages a version of TC and exposes the BOM.

There's an issue with test-containers v1.19 and test-resources, which this causes to be exposed in the data-mongo guides

I've bumped the version as this needs to be a minor release due to semver

