### PR TITLE
Fix ConnectionPool CNFE when r2dbc-pool is undeclared

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ micronaut-sql = "7.0.1-M1"
 micronaut-flyway = "8.0.0-M3"
 micronaut-validation = "5.0.0-M1"
 micronaut-logging = "2.0.0-M2"
+micronaut-micrometer = "5.13.2"
 
 groovy = "5.0.3"
 
@@ -48,6 +49,7 @@ micronaut-flyway = { module = "io.micronaut.flyway:micronaut-flyway-bom", versio
 micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
+micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-core", version.ref = "micronaut-micrometer" }
 
 # R2DBC API
 

--- a/r2dbc-core/build.gradle
+++ b/r2dbc-core/build.gradle
@@ -18,8 +18,10 @@ dependencies {
 
     api(platform(mnReactor.boms.reactor))
     implementation(mn.reactor)
+    implementation(libs.managed.r2dbc.pool)
 
     testImplementation(mn.micronaut.management)
+    testImplementation(libs.micronaut.micrometer)
 
     testImplementation(mnRxjava2.micronaut.rxjava2)
     testImplementation(mnTestResources.testcontainers.r2dbc)

--- a/r2dbc-core/build.gradle
+++ b/r2dbc-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     api(platform(mnReactor.boms.reactor))
     implementation(mn.reactor)
-    implementation(libs.managed.r2dbc.pool)
+    runtimeOnly(libs.managed.r2dbc.pool)
 
     testImplementation(mn.micronaut.management)
     testImplementation(libs.micronaut.micrometer)

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.r2dbc.config
+
+import io.micronaut.context.ApplicationContext
+import io.micrometer.core.instrument.binder.MeterBinder
+import io.r2dbc.spi.ConnectionFactory
+import spock.lang.Specification
+
+class R2dbcPoolOptionalDependencySpec extends Specification {
+
+    void 'application context starts without r2dbc-pool on the application classpath'() {
+        given:
+        ApplicationContext context
+
+        when:
+        context = ApplicationContext.run([
+                'r2dbc.datasources.default.url': 'r2dbc:h2:mem:///testdb'
+        ])
+
+        then:
+        context.getBean(ConnectionFactory) != null
+        !context.getBeansOfType(MeterBinder).isEmpty()
+
+        cleanup:
+        context?.close()
+    }
+}

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
@@ -19,7 +19,7 @@ class R2dbcPoolOptionalDependencySpec extends Specification {
         then:
         context.getBean(ConnectionFactory) != null
         context.getBeanDefinitions(MeterBinder)
-            .any { it.toString().contains('R2dbcPoolMetricsBinderFactory#r2dbcPoolMeterBinder') }
+            .any { it.declaringType.present && it.declaringType.get().name == 'io.micronaut.configuration.metrics.binder.r2dbc.R2dbcPoolMetricsBinderFactory' }
 
         cleanup:
         context?.close()

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/config/R2dbcPoolOptionalDependencySpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
 
 class R2dbcPoolOptionalDependencySpec extends Specification {
 
-    void 'application context starts without r2dbc-pool on the application classpath'() {
+    void 'application context starts without an explicit r2dbc-pool declaration in the application'() {
         given:
         ApplicationContext context
 
@@ -18,7 +18,8 @@ class R2dbcPoolOptionalDependencySpec extends Specification {
 
         then:
         context.getBean(ConnectionFactory) != null
-        !context.getBeansOfType(MeterBinder).isEmpty()
+        context.getBeanDefinitions(MeterBinder)
+            .any { it.toString().contains('R2dbcPoolMetricsBinderFactory#r2dbcPoolMeterBinder') }
 
         cleanup:
         context?.close()


### PR DESCRIPTION
## Summary
- add `r2dbc-pool` as a runtime dependency of `micronaut-r2dbc-core`
- add a regression test that reproduces Micrometer binder resolution without an app-level `r2dbc-pool` declaration
- keep existing H2 connection configuration behavior covered by focused verification

## Verification
- `./gradlew :micronaut-r2dbc-core:test --tests io.micronaut.r2dbc.config.R2dbcPoolOptionalDependencySpec`
- `./gradlew :micronaut-r2dbc-core:test --tests io.micronaut.r2dbc.config.R2dbcPoolOptionalDependencySpec --tests io.micronaut.r2dbc.h2.H2ConnectionFactoryConfigurationSpec --tests io.micronaut.r2dbc.h2.H2ConnectionSpec`

Resolves #377
