### PR TITLE
Clarify Cloud SQL R2DBC configuration for Cloud Run

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ managed-r2dbc-h2 = "1.1.0.RELEASE"
 managed-r2dbc-mariadb = "1.4.0"
 managed-r2dbc-postgresql = "1.1.1.RELEASE"
 managed-r2dbc-mssql = "1.0.4.RELEASE"
+managed-cloud-sql-connector = "1.28.2"
 
 # Gradle plugins
 
@@ -61,6 +62,7 @@ managed-r2dbc-mariadb = { module = "org.mariadb:r2dbc-mariadb", version.ref = "m
 managed-r2dbc-mysql = { module = "io.asyncer:r2dbc-mysql", version.ref = "managed-r2dbc-mysql" }
 managed-r2dbc-mssql = { module = "io.r2dbc:r2dbc-mssql", version.ref = "managed-r2dbc-mssql" }
 managed-r2dbc-postgresql = { module = "org.postgresql:r2dbc-postgresql", version.ref = "managed-r2dbc-postgresql" }
+managed-cloud-sql-connector-r2dbc-postgres = { module = "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres", version.ref = "managed-cloud-sql-connector" }
 
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter" }
 

--- a/r2dbc-core/build.gradle
+++ b/r2dbc-core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     // postgres
     testImplementation(libs.managed.r2dbc.postgresql)
+    testImplementation(libs.managed.cloud.sql.connector.r2dbc.postgres)
     testImplementation(mnTestResources.testcontainers.postgres)
     testImplementation(mnSql.postgresql)
 

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/DefaultBasicR2dbcPropertiesSpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/DefaultBasicR2dbcPropertiesSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.r2dbc
+
+import io.micronaut.context.env.Environment
+import io.micronaut.core.type.Argument
+import io.r2dbc.spi.ConnectionFactoryOptions
+import spock.lang.Specification
+
+import java.util.Optional
+
+class DefaultBasicR2dbcPropertiesSpec extends Specification {
+
+    void 'test pooled cloud sql url builder'() {
+        given:
+        Environment environment = Stub() {
+            getProperty('r2dbc.datasources.default.url', Argument.STRING) >> Optional.of('r2dbc:pool:gcp:postgres://db-user:db-pass@project:us-central1:db-instance/appdb')
+        }
+
+        DefaultBasicR2dbcProperties properties = new DefaultBasicR2dbcProperties('default', environment)
+        ConnectionFactoryOptions options = properties.builder().build()
+
+        expect:
+        options.getValue(ConnectionFactoryOptions.DRIVER) == 'pool'
+        options.getValue(ConnectionFactoryOptions.PROTOCOL) == 'gcp:postgres'
+        options.getValue(ConnectionFactoryOptions.HOST) == 'project:us-central1:db-instance'
+        options.getValue(ConnectionFactoryOptions.DATABASE) == 'appdb'
+        options.getValue(ConnectionFactoryOptions.USER) == 'db-user'
+        options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'db-pass'
+    }
+}

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/GcpPostgresConnectionFactoryConfigurationSpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/GcpPostgresConnectionFactoryConfigurationSpec.groovy
@@ -1,0 +1,58 @@
+package io.micronaut.r2dbc.postgresql
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.r2dbc.BasicR2dbcProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryOptions
+import io.r2dbc.spi.Option
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(rebuildContext = true)
+class GcpPostgresConnectionFactoryConfigurationSpec extends Specification {
+
+    @Inject ApplicationContext context
+
+    @Property(name = 'r2dbc.datasources.default.url', value = 'r2dbc:gcp:postgres://db-user:db-pass@project:us-central1:db-instance/appdb')
+    void 'test cloud sql url configuration'() {
+        given:
+        BasicR2dbcProperties props = context.getBean(BasicR2dbcProperties)
+        ConnectionFactoryOptions options = context.getBean(ConnectionFactoryOptions)
+        ConnectionFactory connectionFactory = context.getBean(ConnectionFactory)
+
+        expect:
+        props != null
+        options.getValue(ConnectionFactoryOptions.DRIVER) == 'gcp'
+        options.getValue(ConnectionFactoryOptions.PROTOCOL) == 'postgres'
+        options.getValue(ConnectionFactoryOptions.HOST) == 'project:us-central1:db-instance'
+        options.getValue(ConnectionFactoryOptions.DATABASE) == 'appdb'
+        options.getValue(ConnectionFactoryOptions.USER) == 'db-user'
+        options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'db-pass'
+        connectionFactory.class.name.contains('CloudSqlConnectionFactory')
+    }
+
+    @Property(name = 'r2dbc.datasources.default.driver', value = 'gcp')
+    @Property(name = 'r2dbc.datasources.default.protocol', value = 'postgresql')
+    @Property(name = 'r2dbc.datasources.default.host', value = 'project:us-central1:db-instance')
+    @Property(name = 'r2dbc.datasources.default.database', value = 'appdb')
+    @Property(name = 'r2dbc.datasources.default.username', value = 'db-user')
+    @Property(name = 'r2dbc.datasources.default.password', value = 'password')
+    @Property(name = 'r2dbc.datasources.default.options.ENABLE_IAM_AUTH', value = 'true')
+    void 'test cloud sql properties configuration'() {
+        given:
+        ConnectionFactoryOptions options = context.getBean(ConnectionFactoryOptions)
+        ConnectionFactory connectionFactory = context.getBean(ConnectionFactory)
+
+        expect:
+        options.getValue(ConnectionFactoryOptions.DRIVER) == 'gcp'
+        options.getValue(ConnectionFactoryOptions.PROTOCOL) == 'postgresql'
+        options.getValue(ConnectionFactoryOptions.HOST) == 'project:us-central1:db-instance'
+        options.getValue(ConnectionFactoryOptions.DATABASE) == 'appdb'
+        options.getValue(ConnectionFactoryOptions.USER) == 'db-user'
+        options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'password'
+        options.getValue(Option.valueOf('ENABLE_IAM_AUTH')) == 'true'
+        connectionFactory.class.name.contains('CloudSqlConnectionFactory')
+    }
+}

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/GcpPostgresConnectionFactoryConfigurationSpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/GcpPostgresConnectionFactoryConfigurationSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.r2dbc.postgresql
 
+import com.google.cloud.sql.core.CloudSqlConnectionFactory
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.r2dbc.BasicR2dbcProperties
@@ -30,7 +31,7 @@ class GcpPostgresConnectionFactoryConfigurationSpec extends Specification {
         options.getValue(ConnectionFactoryOptions.DATABASE) == 'appdb'
         options.getValue(ConnectionFactoryOptions.USER) == 'db-user'
         options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'db-pass'
-        connectionFactory.class.name.contains('CloudSqlConnectionFactory')
+        connectionFactory instanceof CloudSqlConnectionFactory
     }
 
     @Property(name = 'r2dbc.datasources.default.driver', value = 'gcp')
@@ -52,7 +53,7 @@ class GcpPostgresConnectionFactoryConfigurationSpec extends Specification {
         options.getValue(ConnectionFactoryOptions.DATABASE) == 'appdb'
         options.getValue(ConnectionFactoryOptions.USER) == 'db-user'
         options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'password'
-        options.getValue(Option.valueOf('ENABLE_IAM_AUTH')) == 'true'
-        connectionFactory.class.name.contains('CloudSqlConnectionFactory')
+        (options.getValue(Option.valueOf('ENABLE_IAM_AUTH')) as Boolean) == true
+        connectionFactory instanceof CloudSqlConnectionFactory
     }
 }

--- a/src/main/docs/guide/availableDrivers.adoc
+++ b/src/main/docs/guide/availableDrivers.adoc
@@ -46,14 +46,16 @@ To use PostgreSQL through the Google Cloud SQL R2DBC connector, add the Cloud SQ
 
 dependency:com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres[scope="runtimeOnly"]
 
-Use a full Cloud SQL URL for the datasource:
+Use a full Cloud SQL URL for the datasource and provide credentials separately (for example via environment variables or secret injection):
 
 [source,yaml]
 ----
 r2dbc:
   datasources:
     default:
-      url: r2dbc:gcp:postgres://<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+      url: r2dbc:gcp:postgres://<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+      username: ${DB_USER}
+      password: ${DB_PASS}
 ----
 
 If you also want R2DBC pooling, compose the delegated driver layers in the URL instead of trying to split `gcp` and `pool` across separate `driver` and `options.driver` properties:
@@ -63,8 +65,12 @@ If you also want R2DBC pooling, compose the delegated driver layers in the URL i
 r2dbc:
   datasources:
     default:
-      url: r2dbc:pool:gcp:postgres://<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+      url: r2dbc:pool:gcp:postgres://<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+      username: ${DB_USER}
+      password: ${DB_PASS}
 ----
+
+The protocol segment accepts both `postgres` and `postgresql`.
 
 ==== SQL Server
 

--- a/src/main/docs/guide/availableDrivers.adoc
+++ b/src/main/docs/guide/availableDrivers.adoc
@@ -40,6 +40,32 @@ And for Flyway migrations the JDBC driver:
 
 dependency:org.postgresql:postgresql[scope="runtimeOnly"]
 
+===== Google Cloud SQL
+
+To use PostgreSQL through the Google Cloud SQL R2DBC connector, add the Cloud SQL connector dependency alongside the PostgreSQL R2DBC driver:
+
+dependency:com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres[scope="runtimeOnly"]
+
+Use a full Cloud SQL URL for the datasource:
+
+[source,yaml]
+----
+r2dbc:
+  datasources:
+    default:
+      url: r2dbc:gcp:postgres://<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+----
+
+If you also want R2DBC pooling, compose the delegated driver layers in the URL instead of trying to split `gcp` and `pool` across separate `driver` and `options.driver` properties:
+
+[source,yaml]
+----
+r2dbc:
+  datasources:
+    default:
+      url: r2dbc:pool:gcp:postgres://<DB_USER>:<DB_PASS>@<CLOUD_SQL_CONNECTION_NAME>/<DATABASE_NAME>
+----
+
 ==== SQL Server
 
 R2DBC Driver:


### PR DESCRIPTION
## Summary
- document the supported Google Cloud SQL R2DBC dependency and URL forms
- clarify that pooled Cloud SQL connections should use a composed `r2dbc:pool:gcp:postgres://...` URL
- add regression tests covering direct Cloud SQL configuration and pooled URL option parsing

## Verification
- `./gradlew :micronaut-r2dbc-core:test --tests 'io.micronaut.r2dbc.DefaultBasicR2dbcPropertiesSpec' --tests 'io.micronaut.r2dbc.postgresql.GcpPostgresConnectionFactoryConfigurationSpec'`\n- `./gradlew spotlessCheck`\n- `./gradlew docs`
 
Resolves #509