### PR TITLE
Normalize kebab-case R2DBC options

### DIFF
--- a/r2dbc-core/src/main/java/io/micronaut/r2dbc/DefaultBasicR2dbcProperties.java
+++ b/r2dbc-core/src/main/java/io/micronaut/r2dbc/DefaultBasicR2dbcProperties.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
@@ -85,7 +86,7 @@ public class DefaultBasicR2dbcProperties implements BasicR2dbcProperties {
         if (CollectionUtils.isNotEmpty(options)) {
             options.forEach((key, value) ->
                     getBuilder().option(
-                            Option.valueOf(key),
+                            Option.valueOf(normalizeOptionKey(key)),
                             value
                     )
             );
@@ -227,5 +228,9 @@ public class DefaultBasicR2dbcProperties implements BasicR2dbcProperties {
                 ConnectionFactoryOptions.DATABASE, database
         );
         return this;
+    }
+
+    private static String normalizeOptionKey(String key) {
+        return NameUtils.isHyphenatedLowerCase(key) ? NameUtils.camelCase(key) : key;
     }
 }

--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/h2/H2ConnectionFactoryConfigurationSpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/h2/H2ConnectionFactoryConfigurationSpec.groovy
@@ -44,6 +44,18 @@ class H2ConnectionFactoryConfigurationSpec extends Specification {
         options.getValue(Option.valueOf('DB_CLOSE_DELAY')) == '10'
     }
 
+    @Property(name = 'r2dbc.datasources.default.protocol', value = "mem")
+    @Property(name = 'r2dbc.datasources.default.driver', value = "h2")
+    @Property(name = 'r2dbc.datasources.default.database', value = "testdb3")
+    @Property(name = 'r2dbc.datasources.default.options.max-size', value = "48")
+    void 'test kebab-case options are normalized to camel case'() {
+        given:
+        BasicR2dbcProperties props = context.getBean(BasicR2dbcProperties)
+        ConnectionFactoryOptions options = context.getBean(ConnectionFactoryOptions)
 
+        expect:
+        props != null
+        options.getValue(Option.valueOf('maxSize')) == '48'
+    }
 
 }


### PR DESCRIPTION
## Summary
- normalize hyphenated datasource option keys to camelCase before building R2DBC options
- keep raw option keys like `DB_CLOSE_DELAY` unchanged
- add a focused regression test for `options.max-size`

Resolves #289