### PR TITLE
docs: clarify PostgreSQL native-image driver requirement

### DIFF
--- a/src/main/docs/guide/availableDrivers.adoc
+++ b/src/main/docs/guide/availableDrivers.adoc
@@ -36,6 +36,8 @@ R2DBC Driver:
 
 dependency:org.postgresql:r2dbc-postgresql[scope="runtimeOnly"]
 
+NOTE: For GraalVM native images, use a recent `org.postgresql:r2dbc-postgresql` version. Older `0.9.x` releases do not include the native-image reflection metadata required by the PostgreSQL codec layer and can fail at runtime with errors about array types such as `Instant[]`. The Micronaut R2DBC BOM manages a compatible version for you, but if you override the driver version manually, use `1.0.2.RELEASE` or newer.
+
 And for Flyway migrations the JDBC driver:
 
 dependency:org.postgresql:postgresql[scope="runtimeOnly"]


### PR DESCRIPTION
## Summary
- document that GraalVM native images require a recent `org.postgresql:r2dbc-postgresql` version
- explain that older `0.9.x` releases are missing the PostgreSQL native-image metadata
- point users who override the managed version to `1.0.2.RELEASE` or newer

## Verification
- resolved `:micronaut-test-graalvm:micronaut-postgres` runtimeClasspath and confirmed `org.postgresql:r2dbc-postgresql:1.1.1.RELEASE`
- inspected the resolved JAR and confirmed it contains the native-image `reflect-config.json` entries for the reported array types
- ran `./gradlew :micronaut-r2dbc-core:processResources --console=plain`

Resolves #273