### PR TITLE
Add Kotlin native regression coverage for repository operations

### DIFF
--- a/test-graalvm/h2/build.gradle.kts
+++ b/test-graalvm/h2/build.gradle.kts
@@ -1,8 +1,30 @@
 plugins {
     id("io.micronaut.build.internal.r2dbc-testproject")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.kapt")
+    id("org.jetbrains.kotlin.plugin.allopen")
+    id("io.micronaut.build.internal.r2dbc-kotlin")
+}
+
+allOpen {
+    annotation("io.micronaut.aop.Around")
+}
+
+tasks.named("internalStartTestResourcesService") {
+    enabled = false
+}
+
+tasks.named("startTestResourcesService") {
+    enabled = false
+}
+
+tasks.named("stopTestResourcesService") {
+    enabled = false
 }
 
 dependencies {
     runtimeOnly(libs.managed.r2dbc.h2)
     runtimeOnly(mnSql.h2)
+    kaptTest(mnData.micronaut.data.processor)
+    testImplementation(mnKotlin.micronaut.kotlin.runtime)
 }

--- a/test-graalvm/h2/src/test/kotlin/example/kotlin/KotlinOwnerRepository.kt
+++ b/test-graalvm/h2/src/test/kotlin/example/kotlin/KotlinOwnerRepository.kt
@@ -1,0 +1,12 @@
+package example.kotlin
+
+import io.micronaut.data.model.query.builder.sql.Dialect
+import io.micronaut.data.r2dbc.annotation.R2dbcRepository
+import io.micronaut.data.repository.reactive.ReactorCrudRepository
+import reactor.core.publisher.Mono
+import testgraalvm.domain.Owner
+
+@R2dbcRepository(dialect = Dialect.H2)
+interface KotlinOwnerRepository : ReactorCrudRepository<Owner, Long> {
+    fun findByName(name: String): Mono<Owner>
+}

--- a/test-graalvm/h2/src/test/kotlin/example/kotlin/KotlinRepositoryNativeImageTest.kt
+++ b/test-graalvm/h2/src/test/kotlin/example/kotlin/KotlinRepositoryNativeImageTest.kt
@@ -1,0 +1,35 @@
+package example.kotlin
+
+import io.micronaut.data.r2dbc.operations.R2dbcOperations
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import testgraalvm.domain.Owner
+import jakarta.inject.Inject
+
+@MicronautTest(transactional = false)
+class KotlinRepositoryNativeImageTest {
+
+    @Inject
+    lateinit var operations: R2dbcOperations
+
+    @Inject
+    lateinit var repository: KotlinOwnerRepository
+
+    @Test
+    fun kotlinRepositorySaveUsesRepositoryOperationsInNativeImage() {
+        val saved = Mono.from(operations.withTransaction {
+            repository.save(Owner("Wilma", 36))
+        }).block()
+
+        assertNotNull(saved)
+        assertNotNull(saved!!.id)
+        assertEquals("Wilma", saved.name)
+
+        val fetched = repository.findByName("Wilma").block()
+        assertNotNull(fetched)
+        assertEquals(saved.id, fetched!!.id)
+    }
+}


### PR DESCRIPTION
## Summary
- add Kotlin-native H2 regression coverage for repository save and lookup operations
- enable Kotlin test compilation in the H2 GraalVM test module
- disable unused Micronaut Test Resources lifecycle tasks for the in-memory H2 module

## Verification
- ./gradlew :micronaut-test-graalvm:micronaut-h2:test --tests example.kotlin.KotlinRepositoryNativeImageTest
- ./gradlew :micronaut-test-graalvm:micronaut-h2:nativeTest

Resolves #161