### PR TITLE
Clarify Docker R2DBC host configuration

### DIFF
--- a/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/PostgresConnectionFactoryConfigurationSpec.groovy
+++ b/r2dbc-core/src/test/groovy/io/micronaut/r2dbc/postgresql/PostgresConnectionFactoryConfigurationSpec.groovy
@@ -1,0 +1,35 @@
+package io.micronaut.r2dbc.postgresql
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.r2dbc.BasicR2dbcProperties
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.r2dbc.spi.ConnectionFactoryOptions
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@MicronautTest(rebuildContext = true)
+class PostgresConnectionFactoryConfigurationSpec extends Specification {
+    @Inject ApplicationContext context
+
+    @Property(name = 'r2dbc.datasources.default.url', value = 'r2dbc:postgresql://localhost:2709/mydatabase')
+    @Property(name = 'r2dbc.datasources.default.host', value = 'postgres')
+    @Property(name = 'r2dbc.datasources.default.port', value = '5432')
+    @Property(name = 'r2dbc.datasources.default.username', value = 'user')
+    @Property(name = 'r2dbc.datasources.default.password', value = 'secret')
+    void 'test host and port override database URL values'() {
+        given:
+        BasicR2dbcProperties props = context.getBean(BasicR2dbcProperties)
+        ConnectionFactoryOptions options = context.getBean(ConnectionFactoryOptions)
+
+        expect:
+        props != null
+        options.getValue(ConnectionFactoryOptions.DRIVER) == 'postgresql'
+        options.getValue(ConnectionFactoryOptions.DATABASE) == 'mydatabase'
+        options.getValue(ConnectionFactoryOptions.HOST) == 'postgres'
+        options.getValue(ConnectionFactoryOptions.PORT) == 5432
+        options.getValue(ConnectionFactoryOptions.USER) == 'user'
+        options.getValue(ConnectionFactoryOptions.PASSWORD).toString() == 'secret'
+    }
+}

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -45,16 +45,19 @@ flyway: # <1>
       enabled: true
 datasources:
   default: # <2>
-    url: jdbc:mysql://localhost:3306/mydatabase
+    url: ${JDBC_URL:`jdbc:mysql://localhost:3306/mydatabase`}
 r2dbc:
   datasources:
     default: # <3>
       url: r2dbc:mysql:///mydatabase
+      host: ${R2DBC_HOST:localhost} # <4>
+      port: ${R2DBC_PORT:3306}
 ----
 
 <1> The Flyway configuration ensures the schema migration is applied. See https://micronaut-projects.github.io/micronaut-flyway/latest/guide/index.html[Micronaut Flyway] for more information.
-<2> The Flyway configuration needs a JDBC datasource configured, this setting configures one. See https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc[Micronaut JDBC] for more information.
-<3> The property `r2dbc.datasources.default.url` is used to configure the default R2DBC `ConnectionFactory`
+<2> The Flyway configuration needs a JDBC datasource configured, this setting configures one and lets you override it with `JDBC_URL` for container deployments. See https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc[Micronaut JDBC] for more information.
+<3> The property `r2dbc.datasources.default.url` is used to configure the default R2DBC `ConnectionFactory`.
+<4> Override `R2DBC_HOST` and `R2DBC_PORT` when the application runs in Docker or another container so the app connects to the database service instead of the container's own `localhost`.
 
 TIP: The R2DBC `ConnectionFactory` object can be injected anywhere in your code with dependency injection.
 
@@ -75,6 +78,5 @@ snippet::example.AuthorController[project-base="doc-examples/example", source="m
 
 <1> By returning a reactive type that emits many items you can stream data (either rx:Flowable[] or `Flux`)
 <1> By returning a reactive type that emits a single item you return the entire response (either rx:Single[] or `Mono`)
-
 
 


### PR DESCRIPTION
## Summary
- add a regression spec proving explicit PostgreSQL host and port properties override values embedded in the R2DBC URL
- update the quick start guide to recommend container-friendly JDBC and R2DBC configuration overrides instead of relying on `localhost`

## Verification
- `./gradlew :micronaut-r2dbc-core:test --tests io.micronaut.r2dbc.postgresql.PostgresConnectionFactoryConfigurationSpec --rerun-tasks`
- `./gradlew spotlessCheck`

Resolves #484
