### PR TITLE
Remove native-image properties for test-graalvm

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-      - graalimgprops
   pull_request:
     branches:
       - master

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
+      - graalimgprops
   pull_request:
     branches:
       - master

--- a/test-graalvm/common/src/main/resources/META-INF/native-image/io.micronaut.r2dbc/micronaut-r2dbc/test-graalvm/common/native-image.properties
+++ b/test-graalvm/common/src/main/resources/META-INF/native-image/io.micronaut.r2dbc/micronaut-r2dbc/test-graalvm/common/native-image.properties
@@ -1,8 +1,0 @@
-Args =--initialize-at-build-time=org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger \
-    --initialize-at-build-time=org.slf4j.LoggerFactory,org.slf4j.helpers.Reporter,org.slf4j.helpers \
-    --initialize-at-build-time=ch.qos.logback.core.CoreConstants,ch.qos.logback.core.status,ch.qos.logback.core.joran.JoranConstants \
-    --initialize-at-build-time=ch.qos.logback.core.pattern.parser.Parser,ch.qos.logback.core.subst.Parser$1,ch.qos.logback.core.subst.Token,ch.qos.logback.core.subst.NodeToStringTransformer$1 \
-    --initialize-at-build-time=ch.qos.logback.classic.Level,ch.qos.logback.classic.Logger,ch.qos.logback.classic.PatternLayout,ch.qos.logback.classic.spi,ch.qos.logback.classic.LoggerContext \
-    --initialize-at-build-time=ch.qos.logback.core.joran.spi,ch.qos.logback.classic.model,ch.qos.logback.core.spi,ch.qos.logback.core.helpers,ch.qos.logback.core.model \
-    --initialize-at-build-time=ch.qos.logback.core.util,ch.qos.logback.core,ch.qos.logback.classic.util,ch.qos.logback.core.model.processor,ch.qos.logback.classic.encoder \
-    --initialize-at-build-time=ch.qos.logback.classic.joran,ch.qos.logback.classic.pattern,org.xml.sax.helpers


### PR DESCRIPTION
These were added during Micronaut 5 release and tests were failing without these build-time inits. I think after change in micronaut-test (or resources) or native build plugin this is no longer needed.